### PR TITLE
Use warnings instead of -w in shebang

### DIFF
--- a/grepmail
+++ b/grepmail
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/perl
 
 # grepmail
 
@@ -19,6 +19,7 @@ use vars qw( %opts $commandLine $VERSION %message_ids_seen
 use Getopt::Std;
 
 use strict;
+use warnings;
 use Mail::Mbox::MessageParser;
 use FileHandle;
 use Carp;


### PR DESCRIPTION
Using -w can cause grepmail being prevented from running if a library
is emitting warnings.

Debian bug reference: https://bugs.debian.org/584728